### PR TITLE
Prepare monex 1.0.0 release and new monex-1.x branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>org.exist-db.apps</groupId>
     <artifactId>monex</artifactId>
-    <version>0.9.18-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <name>Monex</name>
     <description>An application for monitoring, profiling and inspecting a running eXist-db instance.</description>
@@ -63,7 +63,9 @@
         <project.build.source>1.8</project.build.source>
         <project.build.target>1.8</project.build.target>
 
-        <exist.version>5.0.0-SNAPSHOT</exist.version>
+        <exist.version>4.6.1</exist.version>
+        <min.version>3.7.0-SNAPSHOT</min.version>
+        <max.version>4.99.0</max.version>
 
         <!-- used in the EXPath Package Descriptor -->
         <package-name>http://exist-db.org/apps/monex</package-name>

--- a/src/main/xar-resources/index.html
+++ b/src/main/xar-resources/index.html
@@ -34,7 +34,7 @@
                             Active DB Processes
                         </div>
                         <div class="info-box-number" id="jmx-brokers">
-                            <span data-bind="text: jmx.Database.ActiveBrokers">?</span> of
+                            <span data-bind="text: jmx.Database.ActiveBrokers">?</span> of 
                             <span data-bind="text: jmx.Database.TotalBrokers">?</span>
                         </div>
                     </div>
@@ -77,7 +77,7 @@
                         <span class="info-box-text">
                             Waiting Threads
                         </span>
-                        <span class="info-box-number" data-bind="text: $data.jmx.LockTable.Attempting.length || 0">?</span>
+                        <span class="info-box-number" data-bind="text: $data.jmx.LockManager.WaitingThreads().length || 0">?</span>
                     </div>
                 </div>
             </div><!-- ./col -->
@@ -294,7 +294,7 @@
                             </button>
                         </div>
                     </div><!-- /.box-header -->
-                    <div class="box-body jmx-cache-manager" data-bind="with: findByName($data.jmx.CacheManager, 'org.exist.management.exist:type=CacheManager')">
+                    <div class="box-body jmx-cache-manager" data-bind="with: findByName($data.jmx.CacheManager(), 'org.exist.management.exist:type=CacheManager')">
                         <div class="clearfix">
                             <span class="pull-left">Cache Manager</span>
                             <small class="pull-right">
@@ -304,7 +304,7 @@
                             <div class="progress-bar progress-bar-success progress-cache" data-bind="style: {width: Math.round($data.CurrentSize() / ($data.MaxTotal() / 100)) + '%'}"/>
                         </div>
                     </div>
-                    <div class="box-body jmx-cache-manager" data-bind="with: findByName($data.jmx.CacheManager, 'org.exist.management.exist:type=CollectionCacheManager')">
+                    <div class="box-body jmx-cache-manager" data-bind="with: findByName($data.jmx.CacheManager(), 'org.exist.management.exist:type=CollectionCacheManager')">
                         <div class="clearfix">
                             <span class="pull-left">Collection Cache Manager</span>
                             <small class="pull-right">
@@ -519,24 +519,25 @@
                         <table class="table table-striped">
                             <thead>
                                 <tr>
-                                    <th>Resource</th>
+                                    <th>Thread</th>
                                     <th>Waiting for</th>
+                                    <th>Resource</th>
+                                    <th>Lock mode</th>
+                                    <th>Lock type</th>
                                 </tr>
                             </thead>
-                            <tbody data-bind="visible: !$data.jmx.LockTable.Acquired() || $data.jmx.LockTable.Acquired().length == 0">
+                            <tbody data-bind="visible: $data.jmx.LockManager.WaitingThreads().length == 0">
                                 <tr>
                                     <td colspan="5">No waiting threads</td>
                                 </tr>
                             </tbody>
-                            <tbody data-bind="foreach: jmx.LockTable.Acquired">
+                            <tbody data-bind="foreach: jmx.LockManager.WaitingThreads">
                                 <tr>
-                                    <td data-bind="text: key"/>
-                                    <td data-bind="foreach: value">
-                                        <span data-bind="text: key"/>
-                                        (<span data-bind="foreach: value">
-                                            <span data-bind="text: key"/>
-                                        </span>)
-                                    </td>
+                                    <td data-bind="text: waitingThread"/>
+                                    <td data-bind="text: owner"/>
+                                    <td data-bind="text: id"/>
+                                    <td data-bind="text: lockMode"/>
+                                    <td data-bind="text: lockType"/>
                                 </tr>
                             </tbody>
                         </table>

--- a/src/main/xar-resources/resources/scripts/util.js
+++ b/src/main/xar-resources/resources/scripts/util.js
@@ -63,9 +63,9 @@ JMX.util = (function() {
                 }
             }
             if (data.jmx.LockManager) {
-                var waiting = data.jmx.LockTable.Attempting;
+                var waiting = data.jmx.LockManager.WaitingThreads;
                 if (!waiting || !waiting.length) {
-                    data.jmx.LockTable.Attempting = [];
+                    data.jmx.LockManager.WaitingThreads = [];
                 }
             }
             if (data.jmx.Database) {

--- a/xar-assembly.xml
+++ b/xar-assembly.xml
@@ -18,7 +18,7 @@
     <tag>application</tag>
     <category id="apps">Applications</category>
 
-    <dependency processor="http://exist-db.org" semver-min="${exist.version}" />
+    <dependency processor="http://exist-db.org" semver-min="${min.version}" semver-max="${max.version}" />
     <dependency package="http://exist-db.org/apps/shared"/>
 
     <!-- Collection inside /db/apps where xar-resources will be copied to -->
@@ -145,6 +145,16 @@
         <change version="0.9.17">
             <ul xmlns="http://www.w3.org/1999/xhtml">
                 <li>Repair for eXist 5.0.0 release</li>
+            </ul>
+        </change>
+        <change version="1.0.0">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>Version note: Due to changes in JMX output in eXist 5.x, Monex is now split into a 1.x branch for users of eXist 4.x and the develop branch will carry Monex 2.0 releases for users of eXist 5+</li>
+                <li>Improved: Monex is now built with maven</li>
+                <li>Improved: Removed dependency on Jetty. Monex now uses the standard Java WebSocket API.</li>
+                <li>Improved: Declared front end dependencies via npm.</li>
+                <li>Removed: HipChat module</li>
+                <li>Fixed: Javascript errors when loading various pages</li>
             </ul>
         </change>
     </changelog>


### PR DESCRIPTION
**DO NOT MERGE** until issue below is resolved.

**Update (2019-04-22):** Thanks to @duncdrum, this PR is ok to merge now.

As proposed in https://github.com/eXist-db/monex/issues/73#issuecomment-479898249, this PR establishes a new "monex-1.x" branch targeting eXist 4.x by reverting the change that assumed the eXist 5.x JMX format. This will allow us to publish at least one more release of monex, containing valuable fixes submitted since monex 0.9.17, for users of eXist 4.x. 

While the result builds, it has a problem: the `expath-pkg.xml` produced by the build routine needs to have a `semver-max=4.99.0` declaration in order to prevent installation of this package on eXist 5.x, i.e., to limit installation to eXist 4.x systems. However, maven produces the following:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<package xmlns="http://expath.org/ns/pkg"
         xmlns:xs="http://www.w3.org/2001/XMLSchema"
         name="http://exist-db.org/apps/monex"
         abbrev="monex"
         version="1.0.0-SNAPSHOT"
         spec="1.0">
   <title>Monex</title>
   <home>https://www.github.com/eXist-db/monex</home>
   <dependency processor="http://exist-db.org" semver-min="4.6.0"/>
   <dependency package="http://exist-db.org/apps/shared"/>
</package>
```

So this PR should not be merged until we find some way to get maven to output `semver-max=4.99.0` for the eXist dependency.

Really, of course, we should specify both `semver-max=4.99.0` AND a `semver-min=3.7.0-SNAPSHOT` (that was the [last value before 0.9.17 when we bumped the requirement to 5.0.0](https://github.com/eXist-db/monex/commit/a2c7227f9b80e203615214e50bd8895e5404928b#diff-ae43235febd41aa47310959d7f53c66eL6), but, unfortunately, until the [bug I reported that prevents concurrent use of `semver-min` and `semver-max`](https://github.com/eXist-db/exist/issues/2449) is solved (see also https://github.com/fgeorges/expath-pkg-java/issues/8), we can only use one of these declarations, so we must choose the most important one, `semver-max`.

A side issue: I had expected to be able to specify eXist 4.6.1 in pom.xml, but I got this error during the `mvn package`, so I switched it to 4.6.0:

```
[INFO] ----------------------< org.exist-db.apps:monex >-----------------------
[INFO] Building Monex 1.0.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[WARNING] The POM for org.exist-db:exist-core:jar:4.6.1 is missing, no dependency information available
[WARNING] The POM for org.exist-db:exist-testkit:jar:4.6.1 is missing, no dependency information available
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.644 s
[INFO] Finished at: 2019-04-13T19:17:01-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project monex: Could not resolve dependencies for project org.exist-db.apps:monex:jar:1.0.0-SNAPSHOT: The following artifacts could not be resolved: org.exist-db:exist-core:jar:4.6.1, org.exist-db:exist-testkit:jar:4.6.1: Failure to find org.exist-db:exist-core:jar:4.6.1 in http://repo.evolvedbinary.com/repository/exist-db/ was cached in the local repository, resolution will not be reattempted until the update interval of exist-db has elapsed or updates are forced -> [Help 1]
```

This suggests the eXist 4.6.1 artifacts aren't in the maven repository used by the monex pom.

But again, ultimately, we need to be able to produce `semver-max=4.99.0`.