### PR TITLE
Prepare Monex 2.0.0 (for eXist 5+)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>org.exist-db.apps</groupId>
     <artifactId>monex</artifactId>
-    <version>0.9.18-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>Monex</name>
     <description>An application for monitoring, profiling and inspecting a running eXist-db instance.</description>
@@ -64,6 +64,7 @@
         <project.build.target>1.8</project.build.target>
 
         <exist.version>5.0.0-SNAPSHOT</exist.version>
+        <min.version>5.0.0-RC6</min.version>
 
         <!-- used in the EXPath Package Descriptor -->
         <package-name>http://exist-db.org/apps/monex</package-name>

--- a/xar-assembly.xml
+++ b/xar-assembly.xml
@@ -18,7 +18,7 @@
     <tag>application</tag>
     <category id="apps">Applications</category>
 
-    <dependency processor="http://exist-db.org" semver-min="${exist.version}" />
+    <dependency processor="http://exist-db.org" semver-min="${min.version}" />
     <dependency package="http://exist-db.org/apps/shared"/>
 
     <!-- Collection inside /db/apps where xar-resources will be copied to -->
@@ -145,6 +145,16 @@
         <change version="0.9.17">
             <ul xmlns="http://www.w3.org/1999/xhtml">
                 <li>Repair for eXist 5.0.0 release</li>
+            </ul>
+        </change>
+        <change version="2.0.0">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>Version note: Due to changes in JMX output in eXist 5, Monex is now split into a 1.x branch for users of eXist 4.x and the master branch will carry Monex 2.x releases for users of eXist 5+.</li>
+                <li>Improved: Monex is now built with maven</li>
+                <li>Improved: Removed dependency on Jetty. Monex now uses the standard Java WebSocket API.</li>
+                <li>Improved: Declared front end dependencies via npm.</li>
+                <li>Removed: HipChat module</li>
+                <li>Fixed: Javascript errors when loading various pages</li>
             </ul>
         </change>
     </changelog>


### PR DESCRIPTION
As proposed in https://github.com/eXist-db/monex/issues/73#issuecomment-479898249, this PR (1) includes all changes since the 0.9.17 release, (2) "lowers" the eXist dependency to 5.0.0-RC6, since the previous dependency on 5.0.0-SNAPSHOT prevented installation of monex on 5.0.0-RC* versions of eXist, and (3) establishes the 2.x line of development for monex, which will take place in the master branch (whereas the 1.x line will take place in the monex-1.x branch).

I selected RC6 because (a) Compilation failed when targeting any lower version, as demonstrated by the following error:

```text
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  13.153 s
[INFO] Finished at: 2019-04-13T19:51:29-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:compile (default-compile) on project monex: Compilation failure
[ERROR] /Users/joe/workspace/monex/src/main/java/org/exist/remoteconsole/RemoteConsoleEndpoint.java:[24,22] cannot find symbol
[ERROR]   symbol:   class ThreadUtils
[ERROR]   location: package org.exist.util
```

And (b) RC5 wasn't available in the maven repository used by monex, as demonstrated by the following build failure:

```text
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  0.518 s
[INFO] Finished at: 2019-04-13T19:51:38-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project monex: Could not resolve dependencies for project org.exist-db.apps:monex:jar:2.0.0-SNAPSHOT: The following artifacts could not be resolved: org.exist-db:exist-core:jar:5.0.0-RC5, org.exist-db:exist-testkit:jar:5.0.0-RC5: Failure to find org.exist-db:exist-core:jar:5.0.0-RC5 in http://repo.evolvedbinary.com/repository/exist-db/ was cached in the local repository, resolution will not be reattempted until the update interval of exist-db has elapsed or updates are forced -> [Help 1]
```