### PR TITLE
Add missing dependencies for jetty websocket support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ language: java
 
 dist: xenial
 
+matrix:
+  include:
+    - jdk: openjdk8
+    - jdk: openjdk9
+    - jdk: openjdk10
+    - jdk: openjdk11
+    - jdk: openjdk12
+
 cache:
   directories:
   - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,6 @@
             <groupId>javax.websocket</groupId>
             <artifactId>javax.websocket-api</artifactId>
             <version>1.1</version>
-            <scope>provided</scope>
         </dependency>
         <!-- test dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 
         <exist.version>5.0.0-SNAPSHOT</exist.version>
         <min.version>5.0.0-RC6</min.version>
-        <jetty.version>9.4.19.v20190610</jetty.version>
+        <jackson.version>2.9.8</jackson.version>
 
         <!-- used in the EXPath Package Descriptor -->
         <package-name>http://exist-db.org/apps/monex</package-name>
@@ -90,14 +90,14 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.8</version>
-            <scope>provided</scope>
+            <version>${jackson.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
-            <scope>provided</scope>
+            <version>${jackson.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>javax.websocket</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -105,16 +105,6 @@
             <version>1.1</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>javax-websocket-server-impl</artifactId>
-            <version>${jetty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-server</artifactId>
-            <version>${jetty.version}</version>
-         </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>org.exist-db</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -168,9 +168,7 @@
                         </goals>
                         <configuration>
                             <failOnWarning>true</failOnWarning>
-                            <ignoredUnusedDeclaredDependencies>
-                                <ignoredUnusedDeclaredDependency>com.fasterxml.jackson.core:jackson-annotations:jar:${jackson.version}</ignoredUnusedDeclaredDependency>
-                            </ignoredUnusedDeclaredDependencies>
+                            <ignoreNonCompile>true</ignoreNonCompile>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,6 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>javax.websocket</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -115,12 +115,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.xmlunit</groupId>
-            <artifactId>xmlunit-core</artifactId>
-            <version>2.6.3</version>
-            <scope>test</scope>
-        </dependency>
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
         <exist.version>5.0.0-SNAPSHOT</exist.version>
         <min.version>5.0.0-RC6</min.version>
         <jackson.version>2.9.8</jackson.version>
+        <websocket.api.version>1.1</websocket.api.version>
 
         <!-- used in the EXPath Package Descriptor -->
         <package-name>http://exist-db.org/apps/monex</package-name>
@@ -113,7 +114,7 @@
         <dependency>
             <groupId>javax.websocket</groupId>
             <artifactId>javax.websocket-api</artifactId>
-            <version>1.1</version>
+            <version>${websocket.api.version}</version>
         </dependency>
         <!-- test dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,18 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>3.0.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+            <version>1.4.01</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,9 @@
                         </goals>
                         <configuration>
                             <failOnWarning>true</failOnWarning>
+                            <ignoredUnusedDeclaredDependencies>
+                                <ignoredUnusedDeclaredDependency>com.fasterxml.jackson.core:jackson-annotations:jar:${jackson.version}</ignoredUnusedDeclaredDependency>
+                            </ignoredUnusedDeclaredDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -153,8 +153,23 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <goals>
+                            <goal>analyze-only</goal>
+                        </goals>
+                        <configuration>
+                            <failOnWarning>true</failOnWarning>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.2</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>
-            <scope>compile</scope>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,11 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,12 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.9.8</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.9.8</version>
             <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
 
         <exist.version>5.0.0-SNAPSHOT</exist.version>
         <min.version>5.0.0-RC6</min.version>
+        <jetty.version>9.4.19.v20190610</jetty.version>
 
         <!-- used in the EXPath Package Descriptor -->
         <package-name>http://exist-db.org/apps/monex</package-name>
@@ -98,7 +99,16 @@
             <version>1.1</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>javax-websocket-server-impl</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-server</artifactId>
+            <version>${jetty.version}</version>
+         </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>org.exist-db</groupId>

--- a/src/main/java/org/exist/remoteconsole/RemoteConsoleAdapter.java
+++ b/src/main/java/org/exist/remoteconsole/RemoteConsoleAdapter.java
@@ -19,10 +19,10 @@
  */
 package org.exist.remoteconsole;
 
-import org.exist.console.ConsoleAdapter;
+import org.exist.xquery.XPathException;
 import org.exist.xquery.value.DateTimeValue;
+import org.exist.console.ConsoleAdapter;
 
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
@@ -48,7 +48,7 @@ public class RemoteConsoleAdapter implements ConsoleAdapter {
         final Map<String, Object> data = new HashMap<>();
         data.put("json", json);
         data.put("message", message);
-        data.put("timestamp", new DateTimeValue(new Date()));
+        data.put("timestamp", getTimestamp());
 
         remoteDataWriter.accept(channel, data);
     }
@@ -67,7 +67,7 @@ public class RemoteConsoleAdapter implements ConsoleAdapter {
         data.put("column", column);
         data.put("json", json);
         data.put("message", message);
-        data.put("timestamp", new DateTimeValue(new Date()));
+        data.put("timestamp", getTimestamp());
 
         remoteDataWriter.accept(channel, data);
     }
@@ -75,5 +75,13 @@ public class RemoteConsoleAdapter implements ConsoleAdapter {
     @Override
     public void send(final String channel, final String jsonString) {
         remoteStringWriter.accept(channel, jsonString);
+    }
+
+    private String getTimestamp() {
+        try {
+            return new DateTimeValue().getStringValue();
+        } catch (XPathException e) {
+            return null;
+        }
     }
 }

--- a/src/main/xar-resources/resources/scripts/console.js
+++ b/src/main/xar-resources/resources/scripts/console.js
@@ -3,7 +3,7 @@ var RemoteConsole = (function() {
     var connection;
     var bufferSize = 50;
     var currentChannel = "default";
-    
+
     return {
         connect: function() {
             var rootcontext = location.pathname.slice(0, location.pathname.indexOf("/apps"));
@@ -42,12 +42,12 @@ var RemoteConsole = (function() {
                 }
 
                 var smallScreen = Modernizr.mq('(max-width: 767px)');
-                
+
                 var time = data.timestamp.replace(/^.*T([^\+]+).*$/, "$1");
                 var tr = document.createElement("tr");
                 tr.style.display = "none";
                 tr.className = "message";
-                
+
                 var td = document.createElement("td");
                 td.className = "hidden-xs";
                 td.appendChild(document.createTextNode(time));
@@ -99,7 +99,7 @@ var RemoteConsole = (function() {
                 var btn = document.createElement("button");
                 btn.type = "button";
                 btn.className = "btn btn-default";
-                
+
                 var info = document.createElement("span");
                 info.className = "fa fa-info";
                 btn.appendChild(info);
@@ -111,7 +111,7 @@ var RemoteConsole = (function() {
                     trigger: "click"
                 });
                 tr.appendChild(td);
-                
+
                 $("#console").append(tr);
 
                 $(tr).show(200, function() {

--- a/xar-assembly.xml
+++ b/xar-assembly.xml
@@ -59,6 +59,11 @@
             <artifactId>jackson-annotations</artifactId>
             <version>${jackson.version}</version>
         </dependencySet>
+        <dependencySet>
+            <groupId>javax.websocket</groupId>
+            <artifactId>javax.websocket-api</artifactId>
+            <version>${websocket.api.version}</version>
+        </dependencySet>
     </dependencySets>
 
     <!-- register the Java module to eXist-db -->

--- a/xar-assembly.xml
+++ b/xar-assembly.xml
@@ -59,41 +59,6 @@
             <artifactId>jackson-annotations</artifactId>
             <version>2.9.8</version>
         </dependencySet>
-        <dependencySet>
-            <groupId>javax.websocket</groupId>
-            <artifactId>javax.websocket-api</artifactId>
-            <version>1.1</version>
-        </dependencySet>
-        <dependencySet>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>javax-websocket-server-impl</artifactId>
-            <version>${jetty.version}</version>
-        </dependencySet>
-        <dependencySet>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>javax-websocket-client-impl</artifactId>
-            <version>${jetty.version}</version>
-        </dependencySet>
-        <dependencySet>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-common</artifactId>
-            <version>${jetty.version}</version>
-        </dependencySet>
-        <dependencySet>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-server</artifactId>
-            <version>${jetty.version}</version>
-        </dependencySet>
-        <dependencySet>
-            <groupId>org.eclipse.jetty.websocket</groupId>
-            <artifactId>websocket-client</artifactId>
-            <version>${jetty.version}</version>
-        </dependencySet>
-        <dependencySet>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-client</artifactId>
-            <version>${jetty.version}</version>
-        </dependencySet>
     </dependencySets>
 
     <!-- register the Java module to eXist-db -->

--- a/xar-assembly.xml
+++ b/xar-assembly.xml
@@ -52,12 +52,12 @@
         <dependencySet>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.8</version>
+            <version>${jackson.version}</version>
         </dependencySet>
         <dependencySet>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.8</version>
+            <version>${jackson.version}</version>
         </dependencySet>
     </dependencySets>
 

--- a/xar-assembly.xml
+++ b/xar-assembly.xml
@@ -49,6 +49,51 @@
             <artifactId>${project.artifactId}</artifactId>
             <version>${project.version}</version>
         </dependencySet>
+        <dependencySet>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.8</version>
+        </dependencySet>
+        <dependencySet>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.9.8</version>
+        </dependencySet>
+        <dependencySet>
+            <groupId>javax.websocket</groupId>
+            <artifactId>javax.websocket-api</artifactId>
+            <version>1.1</version>
+        </dependencySet>
+        <dependencySet>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>javax-websocket-server-impl</artifactId>
+            <version>${jetty.version}</version>
+        </dependencySet>
+        <dependencySet>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>javax-websocket-client-impl</artifactId>
+            <version>${jetty.version}</version>
+        </dependencySet>
+        <dependencySet>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-common</artifactId>
+            <version>${jetty.version}</version>
+        </dependencySet>
+        <dependencySet>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-server</artifactId>
+            <version>${jetty.version}</version>
+        </dependencySet>
+        <dependencySet>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-client</artifactId>
+            <version>${jetty.version}</version>
+        </dependencySet>
+        <dependencySet>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
+            <version>${jetty.version}</version>
+        </dependencySet>
     </dependencySets>
 
     <!-- register the Java module to eXist-db -->


### PR DESCRIPTION
eXist core is missing various dependencies required to enable websocket support in Jetty. This PR adds those dependencies to monex itself. It also fixes a few minor bugs causing an NPE at startup.

We should decide if we want core to support jetty websockets or not, and either

1. drop `websocket-servlet` and its dependencies from core
2. add the correct dependencies to core, which would require changes to this PR

See https://github.com/eXist-db/monex/issues/60#issuecomment-502617034

Tests: https://github.com/eXist-db/e2e-core/pull/22