### PR TITLE
fix(xar-assembly): adjust min.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <project.build.target>1.8</project.build.target>
 
         <exist.version>5.1.0-SNAPSHOT</exist.version>
-        <min.version>5.0.0</min.version>
+        <min.version>5.1.0-SNAPSHOT</min.version>
         <jackson.version>2.10.0</jackson.version>
         <websocket.api.version>1.1</websocket.api.version>
 


### PR DESCRIPTION
missed the fact that we have two variables in monex's pom. This is not one of the times where they can diverge. 