### PR TITLE
Add eXist 5 facets & fields browsing to Indexing pane

### DIFF
--- a/src/main/xar-resources/facet.html
+++ b/src/main/xar-resources/facet.html
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">
+    <!-- Content Header (Page header) -->
+    <section class="content-header">
+        <h1>
+            Browse Indexes <small>Browse Index Definitions</small>
+        </h1>
+        <ol class="breadcrumb">
+            <li>
+                <a href="index.html">
+                    <i class="fa fa-dashboard"/> Home</a>
+            </li>
+            <li>
+                <a href="indexes.html">
+                    <i class="fa fa-sort-alpha-desc"/> Indexes</a>
+            </li>
+            <li data-template="indexes:current-collection">Collection</li>
+            <li class="active" data-template="indexes:current-facet">Facet</li>
+        </ol>
+    </section>
+    
+    <!-- Main content -->
+    <section class="content">
+        <div class="box">
+            <div class="box-header with-border">
+                <h3 class="box-title" data-template="indexes:current-facet"/>
+            </div>
+            <div class="box-body" data-template="indexes:show-facet"/>
+        </div>
+    </section>
+    <script type="text/javascript" src="resources/scripts/modernizr.custom.js"/>
+    <script type="text/javascript" src="resources/scripts/knockout-3.1.0.js"/>
+    <script type="text/javascript" src="resources/scripts/knockout.mapping-2.4.1.js"/>
+    <script type="text/javascript" src="resources/scripts/exadmin.js"/>
+</div>

--- a/src/main/xar-resources/field.html
+++ b/src/main/xar-resources/field.html
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">
+    <!-- Content Header (Page header) -->
+    <section class="content-header">
+        <h1>
+            Browse Indexes <small>Browse Index Definitions</small>
+        </h1>
+        <ol class="breadcrumb">
+            <li>
+                <a href="index.html">
+                    <i class="fa fa-dashboard"/> Home</a>
+            </li>
+            <li>
+                <a href="indexes.html">
+                    <i class="fa fa-sort-alpha-desc"/> Indexes</a>
+            </li>
+            <li data-template="indexes:current-collection">Collection</li>
+            <li class="active" data-template="indexes:current-field">Field</li>
+        </ol>
+    </section>
+    
+    <!-- Main content -->
+    <section class="content">
+        <div class="box">
+            <div class="box-header with-border">
+                <h3 class="box-title" data-template="indexes:current-field"/>
+            </div>
+            <div class="box-body" data-template="indexes:show-field"/>
+        </div>
+    </section>
+    <script type="text/javascript" src="resources/scripts/modernizr.custom.js"/>
+    <script type="text/javascript" src="resources/scripts/knockout-3.1.0.js"/>
+    <script type="text/javascript" src="resources/scripts/knockout.mapping-2.4.1.js"/>
+    <script type="text/javascript" src="resources/scripts/exadmin.js"/>
+</div>


### PR DESCRIPTION
This PR extends the Indexing pane to display facets & fields from collection.xconf files. 

**Collection view**

Now shows the facets and fields associated with a Lucene full text index:

> ![Screen Shot 2020-04-25 at 4 43 47 AM](https://user-images.githubusercontent.com/59118/80275522-c6be9900-86af-11ea-90db-431cff52f337.png)

**Facet view**

Shows per-facet labels & counts:

> ![Screen Shot 2020-04-25 at 4 44 46 AM](https://user-images.githubusercontent.com/59118/80275530-d4741e80-86af-11ea-9a4c-835c8e60d765.png)

**Field view**

Shows values & counts:

> ![Screen Shot 2020-04-25 at 4 44 25 AM](https://user-images.githubusercontent.com/59118/80275534-ddfd8680-86af-11ea-8734-be98c26eaa9a.png)

**Caveats**

Not covered in this PR are the following: 

- typed fields
- drilling into hierarchical facets
- searching within fields
- display of `field/@if` attribute

The use of util:eval makes for some ugly string construction of facet & field queries; while this could be cleaned up, I don't know of another way. 

I added wildcard field searches to all facet/field queries to allow results to be returned even if the parent Lucene full text index has `@index="no"`.

