### PR TITLE
Set exist.(java-api|processor).version to 6.1.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,14 @@
         <project.build.source>1.8</project.build.source>
         <project.build.target>1.8</project.build.target>
 
-        <exist.java-api.version>5.4.0</exist.java-api.version>            <!-- The eXist-db XQuery Java Module API version -->
-        <exist.processor.version>6.0.1</exist.processor.version>          <!-- The version of eXist-db needed by this EXPath Module -->
+        <!-- exist.java-api.version: The eXist-db XQuery Java Module API version: 
+            the version of eXist that Monex needs to compile and run the java 
+            code -->
+        <exist.java-api.version>6.1.0-SNAPSHOT</exist.java-api.version>
+        <!-- exist.java-api.version: The version of eXist-db needed by this EXPath Module: 
+            the version of eXist needed to run Monex's XQuery code. This is what gets 
+            declared in the EXPath package descriptor file. -->
+        <exist.processor.version>6.1.0-SNAPSHOT</exist.processor.version>
 
         <jackson.version>2.13.2</jackson.version>
         <websocket.api.version>1.1</websocket.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -456,6 +456,13 @@
     </profile>
   </profiles>
 
+    <repositories>
+        <repository>
+            <id>exist-db</id>
+            <url>https://repo.evolvedbinary.com/repository/exist-db-snapshots/</url>
+        </repository>
+    </repositories>
+
   <pluginRepositories>
     <pluginRepository>
       <id>clojars.org</id>


### PR DESCRIPTION
And add comments fleshing out the difference between the two properties.

Goal: to get CI on master passing again, since it started failing after the recent bump of jackson.core versions in eXist develop and monex master.