### PR TITLE
Require eXist 6.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.exist-db.apps</groupId>
     <artifactId>monex</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>3.0.6-SNAPSHOT</version>
 
     <name>Monex</name>
     <description>An application for monitoring, profiling and inspecting a running eXist-db instance.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.exist-db.apps</groupId>
     <artifactId>monex</artifactId>
-    <version>3.0.5-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
 
     <name>Monex</name>
     <description>An application for monitoring, profiling and inspecting a running eXist-db instance.</description>
@@ -48,8 +48,8 @@
         <project.build.source>1.8</project.build.source>
         <project.build.target>1.8</project.build.target>
 
-        <exist.java-api.version>5.4.0</exist.java-api.version>            <!-- The eXist-db XQuery Java Module API version -->
-        <exist.processor.version>6.0.1</exist.processor.version>          <!-- The version of eXist-db needed by this EXPath Module -->
+        <exist.java-api.version>6.1.0-SNAPSHOT</exist.java-api.version>            <!-- The eXist-db XQuery Java Module API version -->
+        <exist.processor.version>6.1.0-SNAPSHOT</exist.processor.version>          <!-- The version of eXist-db needed by this EXPath Module -->
 
         <jackson.version>2.13.4</jackson.version>
         <websocket.api.version>1.1</websocket.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,8 +48,8 @@
         <project.build.source>1.8</project.build.source>
         <project.build.target>1.8</project.build.target>
 
-        <exist.java-api.version>6.1.0-SNAPSHOT</exist.java-api.version>            <!-- The eXist-db XQuery Java Module API version -->
-        <exist.processor.version>6.1.0-SNAPSHOT</exist.processor.version>          <!-- The version of eXist-db needed by this EXPath Module -->
+        <exist.java-api.version>5.4.0</exist.java-api.version>            <!-- The eXist-db XQuery Java Module API version -->
+        <exist.processor.version>6.1.0</exist.processor.version>          <!-- The version of eXist-db needed by this EXPath Module -->
 
         <jackson.version>2.13.4</jackson.version>
         <websocket.api.version>1.1</websocket.api.version>

--- a/xar-assembly.xml
+++ b/xar-assembly.xml
@@ -246,6 +246,17 @@
                 <li>Fixed: Display all values of a facet - <a href="https://github.com/eXist-db/monex/pull/166">#166</a></li>
             </ul>
         </change>
+        <change version="3.0.5">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>Fixed: Mistyped parameter in post-install.xql - <a href="https://github.com/eXist-db/monex/commit/bbe260744abb8bc0baed00d073383299f76a96cf">ad2868e</a></li>
+            </ul>
+        </change>
+        <change version="4.0.0">
+            <ul xmlns="http://www.w3.org/1999/xhtml">
+                <li>Breaking: Due to internal API changes this version of monex requires eXist-db version 6.1.0 or later - <a href="https://github.com/eXist-db/monex/pull/210">#210</a>, <a href="https://github.com/eXist-db/monex/pull/223">#223</a></li>
+                <li>Fixed: Added missing release notes for 3.0.5 release - <a href="https://github.com/eXist-db/monex/issues/217">#217</a></li>
+            </ul>
+        </change>
     </changelog>
 
 </package>


### PR DESCRIPTION
The slf4japi was updated to v2.x.x in existdb-core and only 6.1.0-SNAPSHOT currently has the needed bridges in place.

The problem here is a hard dependency on slf4japi version 2 which will cause monex not to log any output (silently) on versions of eXist prior to 6.1.0-SNAPSHOT.