### PR TITLE
Adds log4j slf4j activation library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>org.exist-db.apps</groupId>
     <artifactId>monex</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
+    <version>3.0.6-SNAPSHOT</version>
 
     <name>Monex</name>
     <description>An application for monitoring, profiling and inspecting a running eXist-db instance.</description>
@@ -76,6 +76,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>2.0.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>2.19.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Added log4j slf4j activation library enables backwards compatibility on older exist installations.

Signed-off-by: Patrick Reinhart <patrick@reini.net>