### PR TITLE
[build] remove extraneous dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,13 +75,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.6</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j2-impl</artifactId>
-            <version>2.20.0</version>
+            <version>2.0.6</version><!-- maven will use 2.x.x when provided -->
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
- remove extraneous dependency on log4j-slf4j2-impl
  > BASIC RULE Embedded components such as libraries or frameworks should not declare a dependency on any SLF4J binding/provider but only depend on slf4j-api. 
  
  from https://www.slf4j.org/manual.html
