### PR TITLE
Correct the order of the column headings

### DIFF
--- a/src/main/xar-resources/profiling.html
+++ b/src/main/xar-resources/profiling.html
@@ -67,8 +67,8 @@
                         <table class="table table-striped">
                             <thead>
                                 <tr>
-                                    <th>Source</th>
                                     <th>Function</th>
+                                    <th>Source</th>
                                     <th>Calls</th>
                                     <th>Timing</th>
                                 </tr>


### PR DESCRIPTION
The column headings were previously in the wrong order for the data that they show.