### PR TITLE
Describe required version of Node.js and NPM.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,7 @@
   "name": "monex",
   "version": "4.2.1-SNAPSHOT",
   "engines": {
-    "node": ">=18.12.1 <19",
+    "node": ">=18.12.1 <23",
     "npm": ">=9.1.3"
   },
   "lockfileVersion": 2,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.2.1-SNAPSHOT",
   "description": "Monitoring Application for eXist-db",
   "engines": {
-    "node": ">=18.12.1 <19",
+    "node": ">=18.12.1 <23",
     "npm": ">=9.1.3"
   },
   "scripts": {

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
         <websocket.api.version>1.1</websocket.api.version>
         <templating.version>1.0.2</templating.version>
 
-        <node.version>v18.12.1</node.version>
-        <npm.version>9.1.3</npm.version>
+        <node.version>v22.15.0</node.version>
+        <npm.version>10.9.2</npm.version>
     
         <!-- used in the EXPath Package Descriptor -->
         <package-name>http://exist-db.org/apps/monex</package-name>


### PR DESCRIPTION
One of the problems with JavaScript projects is when they don't document or enforce which version of Node.js or NPM is required to build them; without that it becomes a game of guessing and/or whack-a-mole.

This sets the version of Node.js and NPM in package.json to the same as that which was previously specified in the `pom.xml` - https://github.com/eXist-db/monex/blob/master/pom.xml#L58

The existing required version is of course very old. If it is possible to successfully build Monex with a newer version of Node.js and NPM, then I would suggest either:
1. Merging this first, and then sending a follow-up PR to update the version numbers, or
2. tell me the correct version numbers, and I will append a commit to this PR to update them too.