### PR TITLE
put all websocket sessions in a single static map

### DIFF
--- a/src/main/java/org/exist/remoteconsole/RemoteConsoleEndpoint.java
+++ b/src/main/java/org/exist/remoteconsole/RemoteConsoleEndpoint.java
@@ -46,7 +46,7 @@ public class RemoteConsoleEndpoint {
 
     private static final Logger LOG = LoggerFactory.getLogger(RemoteConsoleEndpoint.class);
 
-    private final Map<Session, String> sessions = new ConcurrentHashMap();
+    private static final Map<Session, String> sessions = new ConcurrentHashMap();
 
     public RemoteConsoleEndpoint() {
         ConsoleModule.setAdapter(new RemoteConsoleAdapter(this::sendAll, this::sendAll));


### PR DESCRIPTION
This fixes #305: The `console:log` function could only send to one channel, because it could only reach one session. By putting all sessions in a static map, `console:log` can find the correct session belonging to the channel it wants to log to.