### PR TITLE
chore: use SPDX license header

### DIFF
--- a/LGPL-21-license.template.txt
+++ b/LGPL-21-license.template.txt
@@ -1,19 +1,2 @@
-eXist-db Open Source Native XML Database
+SPDX LGPL-2.1-or-later
 Copyright (C) ${copyright.year} ${copyright.name}
-
-${email}
-${url}
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 2.1 of the License, or (at your option) any later version.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 const { defineConfig } = require('cypress')
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,3 +1,7 @@
+/*
+ * SPDX LGPL-2.1-or-later
+ * Copyright (C) 2017 The eXist-db Authors
+ */
 const { defineConfig } = require('cypress')
 
 module.exports = defineConfig({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 /**
  * an example gulpfile to make ant-less existdb package builds a reality

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 /**
  * an example gulpfile to make ant-less existdb package builds a reality

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -19,6 +19,7 @@
     <groupId>org.exist-db.apps</groupId>
     <artifactId>monex</artifactId>
     <version>4.2.1-SNAPSHOT</version>
+    <inceptionYear>2014</inceptionYear>
 
     <name>Monex</name>
     <description>An application for monitoring, profiling and inspecting a running eXist-db instance.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -1,25 +1,8 @@
 <?xml version="1.0"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -190,8 +190,13 @@
             <headerDefinition>xquery-license-style.xml</headerDefinition>
           </headerDefinitions>
           <mapping>
+            <form>XML_STYLE</form>
+            <g>SLASHSTAR_STYLE</g>
             <java>SLASHSTAR_STYLE</java>
+            <plist>XML_STYLE</plist>
+            <xconf.init>XML_STYLE</xconf.init>
             <xconf>XML_STYLE</xconf>
+            <xml>XML_STYLE</xml>
             <xq>XQUERY_STYLE</xq>
             <xql>XQUERY_STYLE</xql>
             <xqm>XQUERY_STYLE</xqm>
@@ -214,7 +219,6 @@
                 <exclude>README.md</exclude>
                 <exclude>LICENSE</exclude>
                 <exclude>**/LGPL-21-license.template.txt</exclude>
-                <exclude>**/xquery-license-style.xml</exclude>
                 <exclude>xar-assembly.xml</exclude>
                 <exclude>**/vendor/scripts/**</exclude>
                 <exclude>**/indexes-test/data/**</exclude>

--- a/src/main/java/org/exist/console/ConsoleAdapter.java
+++ b/src/main/java/org/exist/console/ConsoleAdapter.java
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 package org.exist.console;
 

--- a/src/main/java/org/exist/console/ConsoleAdapter.java
+++ b/src/main/java/org/exist/console/ConsoleAdapter.java
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.exist.console;
 

--- a/src/main/java/org/exist/console/xquery/ConsoleModule.java
+++ b/src/main/java/org/exist/console/xquery/ConsoleModule.java
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 package org.exist.console.xquery;
 

--- a/src/main/java/org/exist/console/xquery/ConsoleModule.java
+++ b/src/main/java/org/exist/console/xquery/ConsoleModule.java
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.exist.console.xquery;
 

--- a/src/main/java/org/exist/console/xquery/JMXToken.java
+++ b/src/main/java/org/exist/console/xquery/JMXToken.java
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 package org.exist.console.xquery;
 

--- a/src/main/java/org/exist/console/xquery/JMXToken.java
+++ b/src/main/java/org/exist/console/xquery/JMXToken.java
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.exist.console.xquery;
 

--- a/src/main/java/org/exist/console/xquery/Log.java
+++ b/src/main/java/org/exist/console/xquery/Log.java
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 package org.exist.console.xquery;
 

--- a/src/main/java/org/exist/console/xquery/Log.java
+++ b/src/main/java/org/exist/console/xquery/Log.java
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.exist.console.xquery;
 

--- a/src/main/java/org/exist/remoteconsole/RemoteConsoleAdapter.java
+++ b/src/main/java/org/exist/remoteconsole/RemoteConsoleAdapter.java
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.exist.remoteconsole;
 

--- a/src/main/java/org/exist/remoteconsole/RemoteConsoleAdapter.java
+++ b/src/main/java/org/exist/remoteconsole/RemoteConsoleAdapter.java
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 package org.exist.remoteconsole;
 

--- a/src/main/java/org/exist/remoteconsole/RemoteConsoleEndpoint.java
+++ b/src/main/java/org/exist/remoteconsole/RemoteConsoleEndpoint.java
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.exist.remoteconsole;
 

--- a/src/main/java/org/exist/remoteconsole/RemoteConsoleEndpoint.java
+++ b/src/main/java/org/exist/remoteconsole/RemoteConsoleEndpoint.java
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 package org.exist.remoteconsole;
 

--- a/src/main/xar-resources/collection.html
+++ b/src/main/xar-resources/collection.html
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/collection.html
+++ b/src/main/xar-resources/collection.html
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/collection.xconf
+++ b/src/main/xar-resources/collection.xconf
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <collection xmlns="http://exist-db.org/collection-config/1.0">

--- a/src/main/xar-resources/collection.xconf
+++ b/src/main/xar-resources/collection.xconf
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <collection xmlns="http://exist-db.org/collection-config/1.0">

--- a/src/main/xar-resources/console.html
+++ b/src/main/xar-resources/console.html
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/console.html
+++ b/src/main/xar-resources/console.html
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/controller.xql
+++ b/src/main/xar-resources/controller.xql
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "3.1";
 

--- a/src/main/xar-resources/controller.xql
+++ b/src/main/xar-resources/controller.xql
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/controller.xql
+++ b/src/main/xar-resources/controller.xql
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "3.1";
 
 import module namespace login="http://exist-db.org/xquery/login" at "resource:org/exist/xquery/modules/persistentlogin/login.xql";

--- a/src/main/xar-resources/details.html
+++ b/src/main/xar-resources/details.html
@@ -1,24 +1,7 @@
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/details.html
+++ b/src/main/xar-resources/details.html
@@ -1,7 +1,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/error-page.html
+++ b/src/main/xar-resources/error-page.html
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/error-page.html
+++ b/src/main/xar-resources/error-page.html
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/facet.html
+++ b/src/main/xar-resources/facet.html
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/facet.html
+++ b/src/main/xar-resources/facet.html
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/field.html
+++ b/src/main/xar-resources/field.html
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/field.html
+++ b/src/main/xar-resources/field.html
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/index-keys.html
+++ b/src/main/xar-resources/index-keys.html
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/index-keys.html
+++ b/src/main/xar-resources/index-keys.html
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/index.html
+++ b/src/main/xar-resources/index.html
@@ -1,7 +1,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
     <section class="content-header">

--- a/src/main/xar-resources/index.html
+++ b/src/main/xar-resources/index.html
@@ -1,27 +1,9 @@
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
 
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
 -->
-<div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content"><!-- Content Header (Page header) -->
     <section class="content-header">
         <h1>
             Monitoring

--- a/src/main/xar-resources/index.html
+++ b/src/main/xar-resources/index.html
@@ -4,6 +4,8 @@
     Copyright (C) 2014 The eXist-db Authors
 
 -->
+<div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">
+    <!-- Content Header (Page header) -->
     <section class="content-header">
         <h1>
             Monitoring

--- a/src/main/xar-resources/indexes-test/collection.xconf
+++ b/src/main/xar-resources/indexes-test/collection.xconf
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <collection xmlns="http://exist-db.org/collection-config/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:my="my-namespace">

--- a/src/main/xar-resources/indexes-test/collection.xconf
+++ b/src/main/xar-resources/indexes-test/collection.xconf
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <collection xmlns="http://exist-db.org/collection-config/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:my="my-namespace">

--- a/src/main/xar-resources/indexes.html
+++ b/src/main/xar-resources/indexes.html
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/indexes.html
+++ b/src/main/xar-resources/indexes.html
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/instances.xml
+++ b/src/main/xar-resources/instances.xml
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <!--

--- a/src/main/xar-resources/instances.xml
+++ b/src/main/xar-resources/instances.xml
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <!--

--- a/src/main/xar-resources/login.html
+++ b/src/main/xar-resources/login.html
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <html>

--- a/src/main/xar-resources/login.html
+++ b/src/main/xar-resources/login.html
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <html>

--- a/src/main/xar-resources/modules/admin.xql
+++ b/src/main/xar-resources/modules/admin.xql
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "3.1";
 

--- a/src/main/xar-resources/modules/admin.xql
+++ b/src/main/xar-resources/modules/admin.xql
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/modules/admin.xql
+++ b/src/main/xar-resources/modules/admin.xql
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "3.1";
 
 let $action := request:get-parameter("action", ())

--- a/src/main/xar-resources/modules/app.xql
+++ b/src/main/xar-resources/modules/app.xql
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "3.1";
 

--- a/src/main/xar-resources/modules/app.xql
+++ b/src/main/xar-resources/modules/app.xql
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/modules/app.xql
+++ b/src/main/xar-resources/modules/app.xql
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "3.1";
 
 module namespace app="http://exist-db.org/apps/admin/templates";

--- a/src/main/xar-resources/modules/config.xqm
+++ b/src/main/xar-resources/modules/config.xqm
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "3.1";
 

--- a/src/main/xar-resources/modules/config.xqm
+++ b/src/main/xar-resources/modules/config.xqm
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/modules/config.xqm
+++ b/src/main/xar-resources/modules/config.xqm
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "3.1";
 
 (:~

--- a/src/main/xar-resources/modules/indexes.xqm
+++ b/src/main/xar-resources/modules/indexes.xqm
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "3.1";
 

--- a/src/main/xar-resources/modules/indexes.xqm
+++ b/src/main/xar-resources/modules/indexes.xqm
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/modules/indexes.xqm
+++ b/src/main/xar-resources/modules/indexes.xqm
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "3.1";
 
 (:

--- a/src/main/xar-resources/modules/job.xql
+++ b/src/main/xar-resources/modules/job.xql
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "3.1";
 

--- a/src/main/xar-resources/modules/job.xql
+++ b/src/main/xar-resources/modules/job.xql
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/modules/job.xql
+++ b/src/main/xar-resources/modules/job.xql
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "3.1";
 
 import module namespace config="http://exist-db.org/apps/admin/config" at "config.xqm";

--- a/src/main/xar-resources/modules/notification.xql
+++ b/src/main/xar-resources/modules/notification.xql
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "3.1";
 

--- a/src/main/xar-resources/modules/notification.xql
+++ b/src/main/xar-resources/modules/notification.xql
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/modules/notification.xql
+++ b/src/main/xar-resources/modules/notification.xql
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "3.1";
 
 module namespace notification="http://exist-db.org/apps/monex/notification";

--- a/src/main/xar-resources/modules/remote.xql
+++ b/src/main/xar-resources/modules/remote.xql
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "3.1";
 

--- a/src/main/xar-resources/modules/remote.xql
+++ b/src/main/xar-resources/modules/remote.xql
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/modules/remote.xql
+++ b/src/main/xar-resources/modules/remote.xql
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "3.1";
 
 import module namespace config="http://exist-db.org/apps/admin/config" at "config.xqm";

--- a/src/main/xar-resources/modules/schedule.xql
+++ b/src/main/xar-resources/modules/schedule.xql
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "3.1";
 

--- a/src/main/xar-resources/modules/schedule.xql
+++ b/src/main/xar-resources/modules/schedule.xql
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "3.1";
 
 import module namespace scheduler="http://exist-db.org/xquery/scheduler" at "java:org.exist.xquery.modules.scheduler.SchedulerModule";

--- a/src/main/xar-resources/modules/schedule.xql
+++ b/src/main/xar-resources/modules/schedule.xql
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/modules/suite.xql
+++ b/src/main/xar-resources/modules/suite.xql
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "3.1";
 import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";

--- a/src/main/xar-resources/modules/suite.xql
+++ b/src/main/xar-resources/modules/suite.xql
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/modules/suite.xql
+++ b/src/main/xar-resources/modules/suite.xql
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "3.1";
 import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
 import module namespace console="http://exist-db.org/xquery/console";

--- a/src/main/xar-resources/modules/test-app.xql
+++ b/src/main/xar-resources/modules/test-app.xql
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "3.1";
 

--- a/src/main/xar-resources/modules/test-app.xql
+++ b/src/main/xar-resources/modules/test-app.xql
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "3.1";
 
 module namespace testapp="http://exist-db.org/apps/admin/testapp";

--- a/src/main/xar-resources/modules/test-app.xql
+++ b/src/main/xar-resources/modules/test-app.xql
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/modules/test-timeline-prof.xql
+++ b/src/main/xar-resources/modules/test-timeline-prof.xql
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "3.1";
 

--- a/src/main/xar-resources/modules/test-timeline-prof.xql
+++ b/src/main/xar-resources/modules/test-timeline-prof.xql
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/modules/test-timeline-prof.xql
+++ b/src/main/xar-resources/modules/test-timeline-prof.xql
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "3.1";
 
 import module namespace app="http://exist-db.org/apps/admin/templates" at "app.xql";

--- a/src/main/xar-resources/modules/test-timeline.xql
+++ b/src/main/xar-resources/modules/test-timeline.xql
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "3.1";
 

--- a/src/main/xar-resources/modules/test-timeline.xql
+++ b/src/main/xar-resources/modules/test-timeline.xql
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/modules/test-timeline.xql
+++ b/src/main/xar-resources/modules/test-timeline.xql
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "3.1";
 
 import module namespace app="http://exist-db.org/apps/admin/templates" at "app.xql";

--- a/src/main/xar-resources/modules/unschedule.xql
+++ b/src/main/xar-resources/modules/unschedule.xql
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "3.1";
 

--- a/src/main/xar-resources/modules/unschedule.xql
+++ b/src/main/xar-resources/modules/unschedule.xql
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "3.1";
 
 import module namespace scheduler="http://exist-db.org/xquery/scheduler" at "java:org.exist.xquery.modules.scheduler.SchedulerModule";

--- a/src/main/xar-resources/modules/unschedule.xql
+++ b/src/main/xar-resources/modules/unschedule.xql
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/modules/update-timeline.xql
+++ b/src/main/xar-resources/modules/update-timeline.xql
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "3.1";
 

--- a/src/main/xar-resources/modules/update-timeline.xql
+++ b/src/main/xar-resources/modules/update-timeline.xql
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "3.1";
 
 declare namespace html="http://www.w3.org/1999/xhtml";

--- a/src/main/xar-resources/modules/update-timeline.xql
+++ b/src/main/xar-resources/modules/update-timeline.xql
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/modules/view.xql
+++ b/src/main/xar-resources/modules/view.xql
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 (:~
  : This is the main XQuery which will (by default) be called by controller.xql

--- a/src/main/xar-resources/modules/view.xql
+++ b/src/main/xar-resources/modules/view.xql
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 (:~
  : This is the main XQuery which will (by default) be called by controller.xql
  : to process any URI ending with ".html". It receives the HTML from

--- a/src/main/xar-resources/modules/view.xql
+++ b/src/main/xar-resources/modules/view.xql
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/notifications.xml
+++ b/src/main/xar-resources/notifications.xml
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <notifications>

--- a/src/main/xar-resources/notifications.xml
+++ b/src/main/xar-resources/notifications.xml
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <notifications>

--- a/src/main/xar-resources/post-install.xql
+++ b/src/main/xar-resources/post-install.xql
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "3.1";
 

--- a/src/main/xar-resources/post-install.xql
+++ b/src/main/xar-resources/post-install.xql
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "3.1";
 
 declare namespace repo="http://exist-db.org/xquery/repo";

--- a/src/main/xar-resources/post-install.xql
+++ b/src/main/xar-resources/post-install.xql
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/pre-install.xql
+++ b/src/main/xar-resources/pre-install.xql
@@ -1,4 +1,17 @@
 (:
+ : SPDX LGPL-2.1-or-later
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : SPDX LGPL-2.1
+ : Copyright (C) 2017 The eXist-db Authors
+ :)
+(:
+ : eXist-db Open Source Native XML Database
+ : Copyright (C) 2017 The eXist-db Authors
+ : SPDX LGPL-2.1
+ :)
+(:
  : eXist-db Open Source Native XML Database
  : Copyright (C) 2017 The eXist-db Authors
  :

--- a/src/main/xar-resources/pre-install.xql
+++ b/src/main/xar-resources/pre-install.xql
@@ -1,6 +1,6 @@
 (:
  : SPDX LGPL-2.1-or-later
- : Copyright (C) 2017 The eXist-db Authors
+ : Copyright (C) 2014 The eXist-db Authors
  :)
 xquery version "1.0";
 

--- a/src/main/xar-resources/pre-install.xql
+++ b/src/main/xar-resources/pre-install.xql
@@ -2,36 +2,6 @@
  : SPDX LGPL-2.1-or-later
  : Copyright (C) 2017 The eXist-db Authors
  :)
-(:
- : SPDX LGPL-2.1
- : Copyright (C) 2017 The eXist-db Authors
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- : SPDX LGPL-2.1
- :)
-(:
- : eXist-db Open Source Native XML Database
- : Copyright (C) 2017 The eXist-db Authors
- :
- : info@exist-db.org
- : https://www.exist-db.org
- :
- : This library is free software; you can redistribute it and/or
- : modify it under the terms of the GNU Lesser General Public
- : License as published by the Free Software Foundation; either
- : version 2.1 of the License, or (at your option) any later version.
- :
- : This library is distributed in the hope that it will be useful,
- : but WITHOUT ANY WARRANTY; without even the implied warranty of
- : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- : Lesser General Public License for more details.
- :
- : You should have received a copy of the GNU Lesser General Public
- : License along with this library; if not, write to the Free Software
- : Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- :)
 xquery version "1.0";
 
 import module namespace xmldb="http://exist-db.org/xquery/xmldb";

--- a/src/main/xar-resources/profiling.html
+++ b/src/main/xar-resources/profiling.html
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/profiling.html
+++ b/src/main/xar-resources/profiling.html
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/remotes.html
+++ b/src/main/xar-resources/remotes.html
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/remotes.html
+++ b/src/main/xar-resources/remotes.html
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/resources/css/style.css
+++ b/src/main/xar-resources/resources/css/style.css
@@ -1,25 +1,7 @@
 /**
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-/* Application styles could go here */
 .profiling .nav {
     margin-top: 10px;
 }

--- a/src/main/xar-resources/resources/css/style.css
+++ b/src/main/xar-resources/resources/css/style.css
@@ -1,6 +1,6 @@
 /**
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 .profiling .nav {
     margin-top: 10px;

--- a/src/main/xar-resources/resources/scripts/console.js
+++ b/src/main/xar-resources/resources/scripts/console.js
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 var RemoteConsole = (function() {
 

--- a/src/main/xar-resources/resources/scripts/console.js
+++ b/src/main/xar-resources/resources/scripts/console.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 var RemoteConsole = (function() {
 

--- a/src/main/xar-resources/resources/scripts/details.js
+++ b/src/main/xar-resources/resources/scripts/details.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 $(function() { 
     var xml = $.parseXML($("#jmx-data").text());

--- a/src/main/xar-resources/resources/scripts/details.js
+++ b/src/main/xar-resources/resources/scripts/details.js
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 $(function() { 
     var xml = $.parseXML($("#jmx-data").text());

--- a/src/main/xar-resources/resources/scripts/exadmin.js
+++ b/src/main/xar-resources/resources/scripts/exadmin.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 // util.js must be loaded first, otherwise JMX is undefined
 function findByName(nodes, name) {

--- a/src/main/xar-resources/resources/scripts/exadmin.js
+++ b/src/main/xar-resources/resources/scripts/exadmin.js
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 // util.js must be loaded first, otherwise JMX is undefined
 function findByName(nodes, name) {

--- a/src/main/xar-resources/resources/scripts/loadsource.js
+++ b/src/main/xar-resources/resources/scripts/loadsource.js
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 $(document).ready(function() {
     /* 

--- a/src/main/xar-resources/resources/scripts/loadsource.js
+++ b/src/main/xar-resources/resources/scripts/loadsource.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 $(document).ready(function() {
     /* 

--- a/src/main/xar-resources/resources/scripts/timeline.js
+++ b/src/main/xar-resources/resources/scripts/timeline.js
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 (function($) {
     $.TimelineOptions = function (element) { 

--- a/src/main/xar-resources/resources/scripts/timeline.js
+++ b/src/main/xar-resources/resources/scripts/timeline.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 (function($) {
     $.TimelineOptions = function (element) { 

--- a/src/main/xar-resources/resources/scripts/timerange.js
+++ b/src/main/xar-resources/resources/scripts/timerange.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 (function($) {
     $.TimerangeSetup = function () { 

--- a/src/main/xar-resources/resources/scripts/timerange.js
+++ b/src/main/xar-resources/resources/scripts/timerange.js
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 (function($) {
     $.TimerangeSetup = function () { 

--- a/src/main/xar-resources/resources/scripts/util.js
+++ b/src/main/xar-resources/resources/scripts/util.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 var JMX = {};
 

--- a/src/main/xar-resources/resources/scripts/util.js
+++ b/src/main/xar-resources/resources/scripts/util.js
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 var JMX = {};
 

--- a/src/main/xar-resources/templates/page.html
+++ b/src/main/xar-resources/templates/page.html
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <html data-template="lib:resolve-apps" data-template-abbrev="eXide">

--- a/src/main/xar-resources/templates/page.html
+++ b/src/main/xar-resources/templates/page.html
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <html data-template="lib:resolve-apps" data-template-abbrev="eXide">

--- a/src/main/xar-resources/timeline-cache-lock.xml
+++ b/src/main/xar-resources/timeline-cache-lock.xml
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <root/>

--- a/src/main/xar-resources/timeline-cache-lock.xml
+++ b/src/main/xar-resources/timeline-cache-lock.xml
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <root/>

--- a/src/main/xar-resources/timelines.html
+++ b/src/main/xar-resources/timelines.html
@@ -1,25 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    eXist-db Open Source Native XML Database
+    SPDX LGPL-2.1-or-later
     Copyright (C) 2017 The eXist-db Authors
-
-    info@exist-db.org
-    https://www.exist-db.org
-
-    This library is free software; you can redistribute it and/or
-    modify it under the terms of the GNU Lesser General Public
-    License as published by the Free Software Foundation; either
-    version 2.1 of the License, or (at your option) any later version.
-
-    This library is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-    Lesser General Public License for more details.
-
-    You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/main/xar-resources/timelines.html
+++ b/src/main/xar-resources/timelines.html
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <div xmlns="http://www.w3.org/1999/xhtml" data-template="templates:surround" data-template-with="templates/page.html" data-template-at="content">

--- a/src/test/cypress/e2e/console_spec.cy.js
+++ b/src/test/cypress/e2e/console_spec.cy.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 /// <reference types='cypress' />
 

--- a/src/test/cypress/e2e/console_spec.cy.js
+++ b/src/test/cypress/e2e/console_spec.cy.js
@@ -1,25 +1,7 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
-
 /// <reference types='cypress' />
 
 beforeEach('log in', () => {

--- a/src/test/cypress/e2e/indexes_spec.cy.js
+++ b/src/test/cypress/e2e/indexes_spec.cy.js
@@ -1,3 +1,7 @@
+/*
+ * SPDX LGPL-2.1-or-later
+ * Copyright (C) 2017 The eXist-db Authors
+ */
 /// <reference types="cypress" />
 
 describe('indexes', () => {

--- a/src/test/cypress/e2e/indexes_spec.cy.js
+++ b/src/test/cypress/e2e/indexes_spec.cy.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 /// <reference types="cypress" />
 

--- a/src/test/cypress/e2e/login_spec.cy.js
+++ b/src/test/cypress/e2e/login_spec.cy.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 describe('Login page', () => {
     beforeEach('log in', () => {

--- a/src/test/cypress/e2e/login_spec.cy.js
+++ b/src/test/cypress/e2e/login_spec.cy.js
@@ -1,3 +1,7 @@
+/*
+ * SPDX LGPL-2.1-or-later
+ * Copyright (C) 2017 The eXist-db Authors
+ */
 describe('Login page', () => {
     beforeEach('log in', () => {
     cy.visit('/')

--- a/src/test/cypress/e2e/monitoring_spec.cy.js
+++ b/src/test/cypress/e2e/monitoring_spec.cy.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 /// <reference types="cypress" />
 

--- a/src/test/cypress/e2e/monitoring_spec.cy.js
+++ b/src/test/cypress/e2e/monitoring_spec.cy.js
@@ -1,3 +1,7 @@
+/*
+ * SPDX LGPL-2.1-or-later
+ * Copyright (C) 2017 The eXist-db Authors
+ */
 /// <reference types="cypress" />
 
 describe('Monex index page', () => {

--- a/src/test/cypress/e2e/profiling_spec.cy.js
+++ b/src/test/cypress/e2e/profiling_spec.cy.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 /// <reference types="cypress" />
 

--- a/src/test/cypress/e2e/profiling_spec.cy.js
+++ b/src/test/cypress/e2e/profiling_spec.cy.js
@@ -1,3 +1,7 @@
+/*
+ * SPDX LGPL-2.1-or-later
+ * Copyright (C) 2017 The eXist-db Authors
+ */
 /// <reference types="cypress" />
 
 describe('profiling', () => {

--- a/src/test/cypress/e2e/remote_spec.cy.js
+++ b/src/test/cypress/e2e/remote_spec.cy.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 /// <reference types="cypress" />
 

--- a/src/test/cypress/e2e/remote_spec.cy.js
+++ b/src/test/cypress/e2e/remote_spec.cy.js
@@ -1,3 +1,7 @@
+/*
+ * SPDX LGPL-2.1-or-later
+ * Copyright (C) 2017 The eXist-db Authors
+ */
 /// <reference types="cypress" />
 
 describe('remote monitoring', () => {

--- a/src/test/cypress/plugins/index.js
+++ b/src/test/cypress/plugins/index.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 // ***********************************************************
 // This example plugins/index.js can be used to load plugins

--- a/src/test/cypress/plugins/index.js
+++ b/src/test/cypress/plugins/index.js
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 // ***********************************************************
 // This example plugins/index.js can be used to load plugins

--- a/src/test/cypress/support/commands.js
+++ b/src/test/cypress/support/commands.js
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 // ***********************************************
 // This example commands.js shows you how to

--- a/src/test/cypress/support/commands.js
+++ b/src/test/cypress/support/commands.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 // ***********************************************
 // This example commands.js shows you how to

--- a/src/test/cypress/support/e2e.js
+++ b/src/test/cypress/support/e2e.js
@@ -1,6 +1,6 @@
 /*
  * SPDX LGPL-2.1-or-later
- * Copyright (C) 2017 The eXist-db Authors
+ * Copyright (C) 2014 The eXist-db Authors
  */
 // ***********************************************************
 // This example support/index.js is processed and

--- a/src/test/cypress/support/e2e.js
+++ b/src/test/cypress/support/e2e.js
@@ -1,23 +1,6 @@
 /*
- * eXist-db Open Source Native XML Database
+ * SPDX LGPL-2.1-or-later
  * Copyright (C) 2017 The eXist-db Authors
- *
- * info@exist-db.org
- * https://www.exist-db.org
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 // ***********************************************************
 // This example support/index.js is processed and

--- a/xquery-license-style.xml
+++ b/xquery-license-style.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    SPDX LGPL-2.1-or-later
+    Copyright (C) 2017 The eXist-db Authors
+
+-->
 <additionalHeaders>
     <xquery_style>
         <firstLine>(:</firstLine>
         <beforeEachLine> : </beforeEachLine>
         <endLine> :)</endLine>
-        <afterEachLine>EOL</afterEachLine>
-        <skipLine> </skipLine>
-        <firstLineDetectionPattern>"(\\s|\\t)*/\\*.*$"</firstLineDetectionPattern>
-        <lastLineDetectionPattern>".*\\*/(\\s|\\t)*$"</lastLineDetectionPattern>
+        <firstLineDetectionPattern>\(:.*$</firstLineDetectionPattern>
+        <lastLineDetectionPattern> :\)$</lastLineDetectionPattern>
         <allowBlankLines>false</allowBlankLines>
         <isMultiline>true</isMultiline>
         <padLines>false</padLines>

--- a/xquery-license-style.xml
+++ b/xquery-license-style.xml
@@ -2,7 +2,7 @@
 <!--
 
     SPDX LGPL-2.1-or-later
-    Copyright (C) 2017 The eXist-db Authors
+    Copyright (C) 2014 The eXist-db Authors
 
 -->
 <additionalHeaders>


### PR DESCRIPTION
Switch to much shorter license and copyright header in source files.
see also https://spdx.dev/learn/handling-license-info/