### PR TITLE
chore: depend on exist-apps-parent 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.exist-db</groupId>
         <artifactId>exist-apps-parent</artifactId>
-        <version>1.12.0</version>
+        <version>2.0.0</version>
         <relativePath />
     </parent>
 
@@ -103,12 +103,6 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
@@ -117,14 +111,6 @@
             <artifactId>javax.websocket-api</artifactId>
             <version>${websocket.api.version}</version>
         </dependency>
-
-        <!-- test dependencies -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <reporting>
@@ -182,7 +168,6 @@
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>4.6</version>
         <configuration>
           <failIfMissing>true</failIfMissing>
           <aggregate>true</aggregate>


### PR DESCRIPTION
- remove version from provided license plugin
- remove unused dependencies jackson-annotations and junit

It turned out that both dependencies reported in #312 are actually unused.
At least all tests pass.

supersedes #312