### PR TITLE
chore: update license in POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
 
     <licenses>
         <license>
-            <name>GNU Lesser General Public License, version 2.1</name>
-            <url>https://opensource.org/licenses/LGPL-2.1</url>
+            <name>GNU Lesser General Public License v2.1 or later</name>
+            <url>https://spdx.org/licenses/LGPL-2.1-or-later.html</url>
             <distribution>repo</distribution>
         </license>
     </licenses>


### PR DESCRIPTION
The previous name and link for the license of Monex was outdated and since we are now using SPDX to identify it in source code files  it makes sense to also update them in the POM.