### PR TITLE
[bugfix] Drop functionsOrdered argument from AbstractInternalModule constructor

### DIFF
--- a/src/main/java/org/exist/console/xquery/ConsoleModule.java
+++ b/src/main/java/org/exist/console/xquery/ConsoleModule.java
@@ -66,7 +66,7 @@ public class ConsoleModule extends AbstractInternalModule {
     }
 
     public ConsoleModule(Map<String, List<? extends Object>> parameters) {
-        super(functions, parameters, false);
+        super(functions, parameters);
     }
 
     @Override


### PR DESCRIPTION
Companion to [eXist-db/exist#6384](https://github.com/eXist-db/exist/pull/6384) (closes eXist-db/exist#6378). That PR removes the 3-arg `AbstractInternalModule(FunctionDef[], Map, boolean)` constructor — the base class now always sorts the function table and always binary-searches, so the third argument has no remaining purpose. The flag was the root cause of #6376 (silent function-lookup failure when the FunctionDef[] wasn't sorted).

This one-line change drops the now-removed third argument so the build continues to compile once eXist#6384 merges.

No behavior change at the module level — the previous `false` value was either redundant (true → array was sorted anyway via the static sort idiom, or sort+binary was unnecessary at this module's scale) or implicit in the new always-sort behavior (false → linear scan and always-binary-search are equivalent for correctness; both find the function). The function lookup contract is unchanged.

[This response was co-authored with Claude Code. -Joe]