### PR TITLE
Fix path shortening

### DIFF
--- a/src/main/xar-resources/modules/app.xql
+++ b/src/main/xar-resources/modules/app.xql
@@ -416,15 +416,17 @@ declare %private function app:sort($function as element(), $sort as xs:string) {
         xs:double($function/@elapsed)
 };
 
-declare %private function app:truncate-source($source as xs:string) {
-    if (string-length($source) gt 60) then
-        let $analyze := analyze-string($source, "^(.*/)([^/]+)$")
+declare %private function app:truncate-source($source as xs:string) as element(span) {
+    if (string-length($source) gt 60) then (
+        let $analyze := analyze-string($source, "^(.*[/\\])([^/\\]+)$")
         let $path := $analyze//fn:group[1]
         let $filename := $analyze//fn:group[2]
+        let $display := substring($path, 1, 60 - string-length($filename)) || '[...]' || $filename
         return
-            <span title="{$source}">{substring($path, 1, 60 - string-length($filename)) || '[...]' || $filename}</span>
-    else
-        $source
+            <span title="{$source}">{$display}</span>
+    ) else (
+        <span>{$source}</span>
+    )
 };
 
 

--- a/src/main/xar-resources/modules/app.xql
+++ b/src/main/xar-resources/modules/app.xql
@@ -604,23 +604,24 @@ declare function app:time-navigation-forward($node as node(), $model as map(*), 
         }
 };
 
-declare function app:time-to-milliseconds($dateTime as xs:dateTime) {
+declare function app:time-to-milliseconds($dateTime as xs:dateTime) as xs:integer {
     let $diff := $dateTime - xs:dateTime("1970-01-01T00:00:00Z")
-    return
+    return xs:integer(
         (days-from-duration($diff) * 60 * 60 * 24 +
         hours-from-duration($diff) * 60 * 60 +
         minutes-from-duration($diff) * 60 +
         seconds-from-duration($diff)) * 1000
+    )
 };
 
-declare function app:milliseconds-to-time($timestamp as xs:long) as xs:dateTime {
-    let $days := xs:int($timestamp div 1000 div 24 div 60 div 60)
+declare function app:milliseconds-to-time($timestamp as xs:integer) as xs:dateTime {
+    let $days := xs:integer($timestamp div 1000 div 24 div 60 div 60)
     let $remainder := $timestamp - ($days * 24 * 60 * 60 * 1000)
-    let $hours := xs:int($remainder div 1000 div 60 div 60)
+    let $hours := xs:integer($remainder div 1000 div 60 div 60)
     let $remainder := $remainder - ($hours * 60 * 60 * 1000)
-    let $minutes := xs:int($remainder div 1000 div 60)
+    let $minutes := xs:integer($remainder div 1000 div 60)
     let $remainder := $remainder - ($minutes * 60 * 1000)
-    let $seconds := xs:int($remainder div 1000)
+    let $seconds := xs:integer($remainder div 1000)
     let $millis := format-number($remainder - ($seconds * 1000), "000")
     return
         xs:dateTime("1970-01-01T00:00:00Z") + 

--- a/src/main/xar-resources/modules/test-app.xql
+++ b/src/main/xar-resources/modules/test-app.xql
@@ -10,6 +10,21 @@ import module namespace app="http://exist-db.org/apps/admin/templates" at "app.x
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
+declare variable $testapp:mock-profile := 
+    <stats:calls xmlns:stats="http://exist-db.org/xquery/profiling">
+        <stats:function name="util:binary-to-string" elapsed="0.008" calls="20" source="/db/system/repo/templating-1.2.1/content/lib.xqm [-1:-1]"/>
+        <stats:function name="templates:process-output" elapsed="0.0" calls="3" source="/db/system/repo/templating-1.2.1/content/templates.xqm [237:17]"/>
+        <stats:function name="map:keys" elapsed="0.001" calls="1" source="/db/system/repo/templating-1.2.1/content/templates.xqm [80:30]"/>
+        <stats:function name="exists" elapsed="0.0" calls="9" source="/db/system/repo/templating-1.2.1/content/templates.xqm [270:12]"/>
+        <stats:function name="exists" elapsed="0.0" calls="1" source="/db/system/repo/templating-1.2.1/content/templates.xqm [450:9]"/>
+        <stats:function name="file:exists" elapsed="0.0" calls="1" source="/db/apps/monex/modules/monex.xqm [22:13]"/>
+        <stats:index type="range" source="/db/apps/monex/modules/app.xql [123:84]" elapsed="0.0" calls="4" optimization-level="BASIC"/>
+        <stats:index type="range" source="/db/apps/monex/modules/monex.xqm [28:19]" elapsed="0.0" calls="4" optimization-level="NONE"/>
+        <stats:index type="range" source="/db/apps/monex/modules/config.xqm [25:13]" elapsed="0.0" calls="1" optimization-level="NONE"/>
+        <stats:index type="range" source="/db/system/repo/templating-1.2.1/content/templates.xqm [255:26]" elapsed="0.001" calls="10" optimization-level="OPTIMIZED"/>
+        <stats:index type="range" source="c:\this\is\a\really\long\filesystem\path\on\windows.xql [123:84]" elapsed="0.0" calls="4" optimization-level="BASIC"/>
+    </stats:calls>
+;
 
 declare
     %test:arg("dateTime", "1970-01-01T00:00:00.000Z") %test:assertEquals(0)
@@ -29,4 +44,36 @@ declare
     %test:arg("millis", 1427846520062) %test:assertEquals("2015-04-01T00:02:00.062Z")
 function testapp:millis-to-time($millis as xs:integer) as xs:dateTime {
     app:milliseconds-to-time($millis)
+};
+
+declare
+    %test:assertXPath('<tr><td colspan="4">No statistics available or tracing not enabled.</td></tr>')
+function testapp:index-stats-empty() {
+    app:index-stats(<root/>, map{}, "test")
+};
+
+declare
+    %test:assertEquals("true", "true")
+function testapp:index-stats-shortens-long-paths() {
+    let $rendered := app:index-stats(<root/>, map{ "trace": $testapp:mock-profile }, "test")
+    let $long-paths := $rendered//span[@title]
+    return for $next in $long-paths
+        let $is-shortened := contains($next/string(), '[...]')
+        let $start := substring-before($next/string(), '[...]')
+        let $end := substring-after($next/string(), '[...]')
+        let $matches := 
+          starts-with($next/@title, $start) and 
+          ends-with($next/@title, $end)
+        return if ($is-shortened and $matches and string-length($start) > 0 and string-length($end) > 0) then true() else error((), $next/@title || " <> " || $next/string() || $end || $start) 
+};
+
+declare
+    %test:assertEquals(5, 5)
+function testapp:index-stats-returns-cols-and-rows() {
+    let $rows := app:index-stats(<root/>, map{ "trace": $testapp:mock-profile }, "test")
+    let $first := head($rows)
+    return ( 
+        count($rows),
+        count($first//td)
+    )
 };

--- a/src/main/xar-resources/modules/test-app.xql
+++ b/src/main/xar-resources/modules/test-app.xql
@@ -7,8 +7,6 @@ xquery version "3.1";
 module namespace testapp="http://exist-db.org/apps/admin/testapp";
 
 import module namespace app="http://exist-db.org/apps/admin/templates" at "app.xql";
-import module namespace console="http://exist-db.org/xquery/console";
-
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
@@ -17,11 +15,8 @@ declare
     %test:arg("dateTime", "1970-01-01T00:00:00.000Z") %test:assertEquals(0)
     %test:arg("dateTime", "1971-01-01T00:00:00.000Z") %test:assertEquals(31536000000)
     %test:arg("dateTime", "2014-01-04T23:42:23.423Z") %test:assertEquals(1388878943423)
-function testapp:time-to-millis($dateTime as xs:dateTime) as xs:long {
-    let $millis := app:time-to-milliseconds($dateTime)
-    let $debug1 := console:log("testapp:time-to-millis millis: " ||$millis)
-    return 
-        $millis
+function testapp:time-to-millis($dateTime as xs:string) as xs:integer {
+    app:time-to-milliseconds(xs:dateTime($dateTime))
 };
 
 
@@ -32,12 +27,6 @@ declare
     %test:arg("millis", 1427846400096) %test:assertEquals("2015-04-01T00:00:00.096Z")
     %test:arg("millis", 1427846460066) %test:assertEquals("2015-04-01T00:01:00.066Z")
     %test:arg("millis", 1427846520062) %test:assertEquals("2015-04-01T00:02:00.062Z")
-    
-    
-function testapp:millis-to-time($millis as xs:decimal) as xs:dateTime {
-    let $time := app:milliseconds-to-time($millis)
-    let $debug1 := console:log("testapp:time-to-millis time: " ||$time)
-    
-    return 
-        $time
+function testapp:millis-to-time($millis as xs:integer) as xs:dateTime {
+    app:milliseconds-to-time($millis)
 };


### PR DESCRIPTION
fixes an (updated) version of #36

The shortening of paths does only work for unix path-like strings as it attempts to split the string into a path and a filename.

While trying to write unit tests to ensure the changes work as advertised I noticed that there are several files prefixed with
`test-`. Two of those files were main-modules but `test-app.xql` already contained XQSuite tests.

So I fixed the tests and with it corrected app.xqm and next added some additional tests for the chnages I made.

Please note that these XQSuite tests cannot be run from the build tool (npm) yet and thus are also not in CI yet.
I propose that we do that in a follow-up PR.